### PR TITLE
Add global block warnings

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
@@ -3,7 +3,9 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Terraria.ModLoader;
 
 /// <summary>
-/// This is the superclass for GlobalTile and GlobalWall, combining common code
+/// This is the superclass for GlobalTile and GlobalWall, combining common code.
+/// Note that these methods are called for all block modifications, so performance should be kept in mind.
+/// Do NOT use this class if you only need to modify behavior for specific block types! Use ModBlockType instead.
 /// </summary>
 public abstract class GlobalBlockType : ModType
 {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -8,6 +8,8 @@ namespace Terraria.ModLoader;
 
 /// <summary>
 /// This class allows you to modify the behavior of any tile in the game. Create an instance of an overriding class then call Mod.AddGlobalTile to use this.
+/// Note that these methods are called for all tile modifications, so performance should be kept in mind.
+/// Do NOT use this class if you only need to modify behavior for specific tile types! Use ModTile instead.
 /// </summary>
 public abstract class GlobalTile : GlobalBlockType
 {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
@@ -2,6 +2,8 @@ namespace Terraria.ModLoader;
 
 /// <summary>
 /// This class allows you to modify the behavior of any wall in the game (although admittedly walls don't have much behavior). Create an instance of an overriding class then call Mod.AddGlobalWall to use this.
+/// Note that these methods are called for all wall modifications, so performance should be kept in mind.
+/// Do NOT use this class if you only need to modify behavior for specific wall types! Use ModWall instead.
 /// </summary>
 public abstract class GlobalWall : GlobalBlockType
 {


### PR DESCRIPTION
### What is the new feature?
Adding documentation to the global block, wall, and tile types informing modders of alternate solutions.

### Why should this be part of tModLoader?
So modders don't use global types for everything and screw performance.

### Are there alternative designs?
Getting rid of the global types entirely.

